### PR TITLE
[Mujoco][Github Action] avoid to back to the original path because of  the symbolic link

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -33,7 +33,7 @@ rosdep update --include-eol-distros
 # Install source code
 mkdir -p ~/catkin_ws/src
 cd ~/catkin_ws
-ln -sf ${CI_SOURCE_PATH} src/${REPOSITORY_NAME}
+cp -r ${CI_SOURCE_PATH} src/${REPOSITORY_NAME} # copy the whole contents instead of create symbolic link
 wstool init src
 wstool merge -t src src/${REPOSITORY_NAME}/aerial_robot_${ROS_DISTRO}.rosinstall
 wstool update -t src


### PR DESCRIPTION

### What is this

Since MuJoco need a relative path to laod in .xml file, we have to be careful about the behavior of  the symbolic link.
So we should use `cp` instead of `ln` to entirely copy the contents.

### Details

The test code in Github Action shows following error, because the relative path causes the jump to the orginal place of the symbolic link, and thus disconnect to the other repository (i.e., aerial_robot_3rdparty ) in the same workspace. This is general behavior of symbolic link. So in this PR, we use `cp` to copy the contents to `/home/runner/catkin_ws/src` instead of creating the symbolic link

```
WARNING: mju_openResource: unknown file '/home/runner/catkin_ws/src/jsk_aerial_robot/robots/mini_quadrotor/mujoco/../../../../aerial_robot_3rdparty/mujoco_ros_control/config/world.xml'
```
