### PR TITLE
Changed desire coordinate message to quaternion

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/control/under_actuated_tilted_lqi_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/control/under_actuated_tilted_lqi_controller.h
@@ -36,7 +36,7 @@
 #pragma once
 
 #include <aerial_robot_control/control/under_actuated_lqi_controller.h>
-#include <spinal/DesireCoord.h>
+#include <geometry_msgs/Quaternion.h>
 
 namespace aerial_robot_control
 {

--- a/aerial_robot_control/src/control/under_actuated_tilted_lqi_controller.cpp
+++ b/aerial_robot_control/src/control/under_actuated_tilted_lqi_controller.cpp
@@ -46,7 +46,7 @@ void UnderActuatedTiltedLQIController::initialize(ros::NodeHandle nh,
 {
   UnderActuatedLQIController::initialize(nh, nhp, robot_model, estimator, navigator, ctrl_loop_rate);
 
-  desired_baselink_rot_pub_ = nh_.advertise<spinal::DesireCoord>("desire_coordinate", 1);
+  desired_baselink_rot_pub_ = nh_.advertise<geometry_msgs::Quaternion>("desire_coordinate", 1);
 
   pid_msg_.z.p_term.resize(1);
   pid_msg_.z.i_term.resize(1);
@@ -154,12 +154,14 @@ void UnderActuatedTiltedLQIController::publishGain()
 {
   UnderActuatedLQIController::publishGain();
 
-  double roll,pitch, yaw;
-  robot_model_->getCogDesireOrientation<KDL::Rotation>().GetRPY(roll, pitch, yaw);
+  double qx, qy, qz, qw;
+  robot_model_->getCogDesireOrientation<KDL::Rotation>().GetQuaternion(qx, qy, qz, qw);
 
-  spinal::DesireCoord coord_msg;
-  coord_msg.roll = roll;
-  coord_msg.pitch = pitch;
+  geometry_msgs::Quaternion coord_msg;
+  coord_msg.x = qx;
+  coord_msg.y = qy;
+  coord_msg.z = qz;
+  coord_msg.w = qw;
   desired_baselink_rot_pub_.publish(coord_msg);
 }
 

--- a/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model_ros.h
+++ b/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model_ros.h
@@ -37,8 +37,8 @@
 
 #include <aerial_robot_model/model/aerial_robot_model.h>
 #include <aerial_robot_model/AddExtraModule.h>
+#include <geometry_msgs/Quaternion.h>
 #include <pluginlib/class_loader.h>
-#include <spinal/DesireCoord.h>
 #include <tf/tf.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
@@ -74,6 +74,6 @@ namespace aerial_robot_model {
     //private functions
     void jointStateCallback(const sensor_msgs::JointStateConstPtr& state);
     bool addExtraModuleCallback(aerial_robot_model::AddExtraModule::Request& req, aerial_robot_model::AddExtraModule::Response& res);
-    void desireCoordinateCallback(const spinal::DesireCoordConstPtr& msg);
+    void desireCoordinateCallback(const geometry_msgs::QuaternionConstPtr& msg);
   };
 } //namespace aerial_robot_model

--- a/aerial_robot_model/src/model/base_model/robot_model_ros.cpp
+++ b/aerial_robot_model/src/model/base_model/robot_model_ros.cpp
@@ -91,8 +91,9 @@ namespace aerial_robot_model {
     return false;
   }
 
-  void RobotModelRos::desireCoordinateCallback(const spinal::DesireCoordConstPtr& msg)
+  void RobotModelRos::desireCoordinateCallback(const geometry_msgs::QuaternionConstPtr& msg)
   {
-    robot_model_->setCogDesireOrientation(msg->roll, msg->pitch, msg->yaw);
+    KDL::Rotation rot = KDL::Rotation::Quaternion(msg->x, msg->y, msg->z, msg->w);
+    robot_model_->setCogDesireOrientation(rot);
   }
 } //namespace aerial_robot_model

--- a/aerial_robot_model/test/aerial_robot_model/numerical_jacobians.cpp
+++ b/aerial_robot_model/test/aerial_robot_model/numerical_jacobians.cpp
@@ -28,9 +28,10 @@ namespace aerial_robot_model {
     nhp_.param("feasible_control_torque_diff_thre", feasible_control_torque_diff_thre_, 0.001);
   }
 
-  void NumericalJacobian::desireCoordinateCallback(const spinal::DesireCoordConstPtr& msg)
+  void NumericalJacobian::desireCoordinateCallback(const geometry_msgs::QuaternionConstPtr& msg)
   {
-    getRobotModel().setCogDesireOrientation(msg->roll, msg->pitch, msg->yaw);
+    KDL::Rotation rot = KDL::Rotation::Quaternion(msg->x, msg->y, msg->z, msg->w);
+    getRobotModel().setCogDesireOrientation(rot);
   }
 
   void NumericalJacobian::jointStateCallback(const sensor_msgs::JointStateConstPtr& state)

--- a/aerial_robot_model/test/aerial_robot_model/numerical_jacobians.h
+++ b/aerial_robot_model/test/aerial_robot_model/numerical_jacobians.h
@@ -36,7 +36,7 @@
 #pragma once
 
 #include <aerial_robot_model/model/transformable_aerial_robot_model.h>
-#include <spinal/DesireCoord.h>
+#include <geometry_msgs/Quaternion.h>
 
 namespace aerial_robot_model  {
 
@@ -82,7 +82,7 @@ namespace aerial_robot_model  {
     aerial_robot_model::transformable::RobotModel& getRobotModel() const { return *robot_model_; }
 
     void jointStateCallback(const sensor_msgs::JointStateConstPtr& state);
-    void desireCoordinateCallback(const spinal::DesireCoordConstPtr& msg);
+    void desireCoordinateCallback(const geometry_msgs::QuaternionConstPtr& msg);
 
     //  numerical solution
     virtual const Eigen::MatrixXd thrustForceNumericalJacobian(std::vector<int> joint_indices);

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/state_estimate/attitude/estimator.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/state_estimate/attitude/estimator.h
@@ -69,6 +69,10 @@ public:
     r_.from_euler(desire_attitude_roll, desire_attitude_pitch, desire_attitude_yaw);
   }
 
+  void setCoordinateFromQuaternion(ap::Quaternion quat)
+  {
+    quat.rotation_matrix(r_);
+  }
 
   void update(const ap::Vector3f& gyro, const ap::Vector3f& acc, const ap::Vector3f& mag)
   {

--- a/robots/dragon/include/dragon/dragon_navigation.h
+++ b/robots/dragon/include/dragon/dragon_navigation.h
@@ -38,6 +38,7 @@
 #include <aerial_robot_control/flight_navigation.h>
 #include <sensor_msgs/JointState.h>
 #include <spinal/DesireCoord.h>
+#include <geometry_msgs/Quaternion.h>
 
 namespace aerial_robot_navigation
 {
@@ -72,7 +73,6 @@ namespace aerial_robot_navigation
     void rosParamInit() override;
 
     void setFinalTargetBaselinkRotCallback(const spinal::DesireCoordConstPtr & msg);
-    void targetBaselinkRotCallback(const spinal::DesireCoordConstPtr& msg);
 
     /* target baselink rotation */
     double prev_rotation_stamp_;

--- a/robots/dragon/src/dragon_navigation.cpp
+++ b/robots/dragon/src/dragon_navigation.cpp
@@ -21,7 +21,7 @@ void DragonNavigator::initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
   /* initialize the flight control */
   BaseNavigator::initialize(nh, nhp, robot_model, estimator, loop_du);
 
-  curr_target_baselink_rot_pub_ = nh_.advertise<spinal::DesireCoord>("desire_coordinate", 1);
+  curr_target_baselink_rot_pub_ = nh_.advertise<geometry_msgs::Quaternion>("desire_coordinate", 1);
   joint_control_pub_ = nh_.advertise<sensor_msgs::JointState>("joints_ctrl", 1);
   final_target_baselink_rot_sub_ = nh_.subscribe("final_target_baselink_rot", 1, &DragonNavigator::setFinalTargetBaselinkRotCallback, this);
 
@@ -55,9 +55,9 @@ void DragonNavigator::baselinkRotationProcess()
       else
         curr_target_baselink_rot_ = final_target_baselink_rot_;
 
-      spinal::DesireCoord target_baselink_rot_msg;
-      target_baselink_rot_msg.roll = curr_target_baselink_rot_.x();
-      target_baselink_rot_msg.pitch = curr_target_baselink_rot_.y();
+      KDL::Rotation rot = KDL::Rotation::RPY(curr_target_baselink_rot_.x(), curr_target_baselink_rot_.y(), 0);
+      geometry_msgs::Quaternion target_baselink_rot_msg;
+      rot.GetQuaternion(target_baselink_rot_msg.x, target_baselink_rot_msg.y, target_baselink_rot_msg.z,  target_baselink_rot_msg.w);
       curr_target_baselink_rot_pub_.publish(target_baselink_rot_msg);
 
       prev_rotation_stamp_ = ros::Time::now().toSec();


### PR DESCRIPTION
### What is this
Changed desire coordinate interface from RPY to quaternion to avoid singularity. 

### Details
- Message type of subscriber in spinal is changed, so please rewrite firmware.
